### PR TITLE
WIP: Setup discord bot

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,39 @@
+<div align="center">
+    <img src="https://raw.githubusercontent.com/snapshot-labs/snapshot/develop/public/icon.svg" height="70" alt="Snapshot Logo">
+    <h1>Snapshot - Discord Bot</h1>
+    <strong>
+      This is a Discord Bot for Snapshot.
+    </strong>
+</div>
+<br>
+<div align="center">
+    <img src="https://img.shields.io/github/commit-activity/w/snapshot-labs/snapshot-hub" alt="GitHub commit activity">
+    <a href="https://github.com/snapshot-labs/snapshot-hub/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22">
+        <img src="https://img.shields.io/github/issues/snapshot-labs/snapshot-hub/help wanted" alt="GitHub issues help wanted">
+    </a>
+    <a href="https://telegram.snapshot.org">
+        <img src="https://img.shields.io/badge/Telegram-white?logo=telegram" alt="Telegram">
+    </a>
+    <a href="https://discord.snapshot.org">
+        <img src="https://img.shields.io/discord/707079246388133940.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2" alt="Discord">
+    </a>
+    <a href="https://twitter.com/SnapshotLabs">
+        <img src="https://img.shields.io/twitter/follow/SnapshotLabs?label=SnapshotLabs&style=flat&logo=twitter&color=1DA1F2" alt="Twitter">
+    </a>
+</div>
+
+
+### Development
+
+#### Install dependencies
+```bash
+yarn
+```
+
+#### Run locally
+```bash
+yarn dev
+```
+
+### License
+[MIT](LICENSE).

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,26 @@
+import express from 'express';
+import { sendEventToDiscordSubscribers } from './client';
+import pkg from '../package.json';
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+  return res.json({
+    name: pkg.name,
+    version: pkg.version
+  });
+});
+
+router.post('/event-to-subscribers', async (req, res) => {
+  const event: string = req.body.event || '';
+  const proposalId: string = req.body.proposalId || '';
+
+  try {
+    await sendEventToDiscordSubscribers(event, proposalId);
+    return res.json({ success: true });
+  } catch (e) {
+    return res.json({ error: e });
+  }
+});
+
+export default router;

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,0 +1,362 @@
+import {
+  Client,
+  GatewayIntentBits,
+  REST,
+  Routes,
+  SlashCommandBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  PermissionsBitField,
+  EmbedBuilder,
+  codeBlock,
+  underscore,
+  inlineCode
+} from 'discord.js';
+import db from './db/mysql';
+import removeMd from 'remove-markdown';
+import { shortenAddress } from './helpers/utils';
+import { subs, loadSubscriptions } from './subscriptions';
+import { checkSpace, getProposal } from './helpers/proposal';
+
+const CLIENT_ID = process.env.DISCORD_CLIENT_ID || '';
+const token = process.env.DISCORD_TOKEN || '';
+const sweeperOption = { interval: 300, filter: () => null };
+// const invite = 'https://discord.com/oauth2/authorize?client_id=892847850780762122&permissions=534723951680&scope=bot';
+
+const client: any = new Client({
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.DirectMessages
+  ],
+  // Remove cache for every 5 minutes to prevent memory leaks https://discord.js.org/#/docs/discord.js/stable/class/Sweepers?scrollTo=options
+  sweepers: {
+    messages: sweeperOption,
+    reactions: sweeperOption,
+    users: sweeperOption,
+    applicationCommands: sweeperOption,
+    bans: sweeperOption,
+    emojis: sweeperOption,
+    invites: sweeperOption,
+    guildMembers: sweeperOption,
+    presences: sweeperOption,
+    stageInstances: sweeperOption,
+    stickers: sweeperOption,
+    threadMembers: sweeperOption,
+    threads: sweeperOption,
+    voiceStates: sweeperOption
+  }
+});
+
+export let ready = false;
+
+const commands = [
+  new SlashCommandBuilder()
+    .setName('ping')
+    .setDescription('Make sure the bot is online.')
+    .setDMPermission(false)
+    .setDefaultMemberPermissions(0), // only administrator role
+  new SlashCommandBuilder()
+    .setName('help')
+    .setDescription('List all commands and current notifications.')
+    .setDMPermission(false)
+    .setDefaultMemberPermissions(0),
+  new SlashCommandBuilder()
+    .setName('add')
+    .setDescription('Add notifications on a channel when a proposal start.')
+    .setDMPermission(false)
+    .setDefaultMemberPermissions(0)
+    .addChannelOption(option =>
+      option
+        .setName('channel')
+        .setDescription('Channel to post the events')
+        .setRequired(true)
+    )
+    .addStringOption(option =>
+      option
+        .setName('space')
+        .setDescription('space to subscribe to')
+        .setRequired(true)
+    )
+    .addStringOption(option => option.setName('mention').setDescription('Mention role')),
+  new SlashCommandBuilder()
+    .setName('remove')
+    .setDescription('Remove notifications on a channel.')
+    .setDMPermission(false)
+    .setDefaultMemberPermissions(0)
+    .addChannelOption(option =>
+      option
+        .setName('channel')
+        .setDescription('Channel to post the events')
+        .setRequired(true)
+    )
+    .addStringOption(option =>
+      option
+        .setName('space')
+        .setDescription('space to subscribe to')
+        .setRequired(true)
+    )
+];
+
+const rest = new REST({ version: '10' }).setToken(token);
+
+(async () => {
+  try {
+    console.log('Started refreshing application (/) commands.');
+    await rest.put(Routes.applicationCommands(CLIENT_ID), { body: commands });
+    console.log('Successfully reloaded application (/) commands.');
+  } catch (error) {
+    console.error(error);
+  }
+})();
+
+client.login(token);
+
+export const setActivity = (message, url?) => {
+  try {
+    client.user.setActivity(message, { type: 'WATCHING', url });
+    return true;
+  } catch (e) {
+    console.log('Missing activity', e);
+  }
+};
+
+const checkPermissions = async (channelId, botId) => {
+  try {
+    const discordChannel = await client.channels.fetch(channelId);
+    if (!discordChannel.isTextBased()) return 'Channel is not text';
+    if (!discordChannel.permissionsFor(botId).has(PermissionsBitField.Flags.ViewChannel))
+      return `I do not have permission to view this channel ${discordChannel.toString()}, Add me to the channel and try again`;
+    if (!discordChannel.permissionsFor(botId).has(PermissionsBitField.Flags.SendMessages))
+      return `I do not have permission to send messages in this channel ${discordChannel.toString()}, Add permission and try again`;
+    return true;
+  } catch (error) {
+    console.log('Error checking permissions', error);
+    const channelExistWithName = client.channels.cache.find(c => c.name === channelId);
+    if (channelExistWithName) {
+      return `Make sure the channel is in ${channelExistWithName.toString()} format.`;
+    } else {
+      return `Can't find the channel ${channelId}, please try again.`;
+    }
+  }
+};
+
+client.on('ready', async () => {
+  ready = true;
+  console.log(`Discord bot logged as "${client.user.tag}"`);
+  setActivity('!');
+  await loadSubscriptions();
+});
+
+async function snapshotHelpCommandHandler(interaction) {
+  const subscriptions = await db.queryAsync(
+    'SELECT * FROM subscriptions WHERE guild = ?',
+    interaction.guildId
+  );
+  let subscriptionsDescription = `\n\n**Subscriptions (${subscriptions.length})**\n\n`;
+  if (subscriptions.length > 0) {
+    subscriptions.forEach(subscription => {
+      subscriptionsDescription += `<#${subscription.channel}> ${subscription.space}\n`;
+    });
+  } else {
+    subscriptionsDescription += 'No subscriptions\n';
+  }
+  subscriptionsDescription += `\n**Commands**`;
+  const addSubscriptionExample = codeBlock(
+    `/add channel:#snapshot space:yam.eth mention:@everyone`
+  );
+
+  const removeSubscriptionExample = codeBlock(`/remove channel:#snapshot space:yam.eth`);
+
+  const embed = new EmbedBuilder()
+    .setColor(0x0099ff)
+    .setTitle(underscore('Snapshot bot'))
+    .setDescription(subscriptionsDescription || ' ')
+    .setThumbnail('https://github.com/snapshot-labs/brand/blob/master/icon/icon.png?raw=true')
+    .addFields(
+      { name: '`/ping`', value: 'Description: Make sure the bot is online.' },
+      {
+        name: '`/help`',
+        value: 'Description: List all commands and current notifications.'
+      },
+      {
+        name: '`/add`',
+        value: `Description: Add notifications on a channel when a proposal start.
+        Options:
+        *channel*: Channel to post the events
+        *space*: Space id to subscribe to
+        *mention*: Mention role (optional)
+        Example:
+        ${addSubscriptionExample}`
+      },
+      {
+        name: '`/remove`',
+        value: `Description: Remove notifications on a channel.
+        Options:
+        *channel*: Channel to post the events
+        *space*: Space id to subscribe to
+        Example:
+        ${removeSubscriptionExample}
+
+
+        Have any questions? Join our discord: https://discord.snapshot.org`
+      }
+    );
+  interaction.reply({ embeds: [embed], ephemeral: true }).catch(console.error);
+}
+
+async function snapshotCommandHandler(interaction, commandType) {
+  const ts = parseInt((Date.now() / 1e3).toFixed());
+  const { id: channelId } = interaction.options.getChannel('channel');
+  const space = interaction.options.getString('space');
+  const mention = interaction.options.getString('mention');
+  console.log(
+    'Received',
+    interaction.guildId,
+    interaction.user.username,
+    ':',
+    commandType,
+    channelId,
+    space,
+    mention
+  );
+  if (commandType === 'add') {
+    const permissions = await checkPermissions(channelId, CLIENT_ID);
+    if (permissions !== true) return interaction.reply(permissions).catch(console.error);
+
+    const spaceExist = await checkSpace(space);
+    if (!spaceExist) return interaction.reply(`Space not found: ${inlineCode(space)}`);
+
+    const subscription = [interaction.guildId, channelId, space, mention || '', ts];
+    await db.queryAsync(
+      `INSERT INTO subscriptions (guild, channel, space, mention, created) VALUES (?, ?, ?, ?, ?)
+    ON DUPLICATE KEY UPDATE guild = ?, channel = ?, space = ?, mention = ?, updated = ?`,
+      [...subscription, ...subscription]
+    );
+    await loadSubscriptions();
+    const color = '#21B66F';
+    const embed = new EmbedBuilder()
+      .setColor(color)
+      .addFields(
+        { name: 'Space', value: space, inline: true },
+        { name: 'Channel', value: `<#${channelId}>`, inline: true },
+        { name: 'Mention', value: mention || 'None', inline: true }
+      )
+      .setDescription('You have successfully subscribed to space events.');
+    interaction.reply({ embeds: [embed], ephemeral: true }).catch(console.error);
+  } else if (commandType === 'remove') {
+    const query = `DELETE FROM subscriptions WHERE guild = ? AND channel = ? AND space = ?`;
+    await db.queryAsync(query, [interaction.guildId, channelId, space]);
+    await loadSubscriptions();
+    const color = '#EE4145';
+    const embed = new EmbedBuilder()
+      .setColor(color)
+      .addFields(
+        { name: 'Space', value: space, inline: true },
+        { name: 'Channel', value: `<#${channelId}>`, inline: true }
+      )
+      .setDescription('You have successfully unsubscribed to space events.');
+    interaction.reply({ embeds: [embed], ephemeral: true }).catch(console.error);
+  }
+}
+
+client.on('interactionCreate', async interaction => {
+  if (!interaction.isChatInputCommand()) return;
+
+  if (interaction.commandName === 'ping') {
+    await interaction.reply({
+      content: `Pong! Websocket heartbeat: ${client.ws.ping}ms.`,
+      ephemeral: true
+    });
+  } else if (interaction.commandName === 'help') {
+    snapshotHelpCommandHandler(interaction);
+  } else if (interaction.commandName === 'add') {
+    snapshotCommandHandler(interaction, 'add');
+  } else if (interaction.commandName === 'remove') {
+    snapshotCommandHandler(interaction, 'remove');
+  }
+});
+
+export const sendMessage = async (channel, message) => {
+  try {
+    let speaker = client.channels.cache.get(channel);
+    // Obtains a channel from Discord, or the channel cache if it's already available.
+    if (!speaker) speaker = await client.channels.fetch(channel);
+    await speaker.send(message);
+    return true;
+  } catch (e) {
+    console.log('Discord error:', e);
+  }
+};
+
+export const sendEventToDiscordSubscribers = async (event, proposalId) => {
+  // Only supports proposal/start event
+  if (event !== 'proposal/start') {
+    console.log('[sendEventToDiscordSubscribers] Event not supported: ', event);
+    return;
+  }
+
+  const proposal = await getProposal(proposalId);
+  if (!proposal) {
+    console.log('[sendEventToDiscordSubscribers] Proposal not found: ', proposalId);
+    return;
+  }
+
+  const status = 'Active';
+  const color = '#21B66F';
+
+  const url = `https://snapshot.org/#/${proposal.space.id}/proposal/${proposal.id}`;
+  let components =
+    !proposal.choices.length || proposal.choices.length > 5
+      ? []
+      : [
+        new ActionRowBuilder().addComponents(
+            ...proposal.choices.map((choice, i) =>
+              new ButtonBuilder()
+                .setLabel(choice)
+                .setURL(`${url}?choice=${i + 1}`)
+                .setStyle(ButtonStyle.Link)
+            )
+          )
+        ];
+  components =
+    event === 'proposal/start' && (proposal.type === 'single-choice' || proposal.type === 'basic')
+      ? components
+      : [];
+
+  const limit = 4096 / 16;
+  let preview = removeMd(proposal.body).slice(0, limit);
+  if (proposal.body.length > limit) preview += `... [Read more](${url})`;
+  const avatar = `https://cdn.stamp.fyi/space/${proposal.space.id}?s=56`;
+
+  const embed = new EmbedBuilder()
+    .setColor(color)
+    .setTitle(proposal.title)
+    .setURL(url)
+    .setTimestamp(proposal.created * 1e3)
+    .setAuthor({
+      name: `${proposal.space.name} by ${shortenAddress(proposal.author)}`,
+      iconURL: avatar
+    })
+    .addFields(
+      { name: 'Status', value: status, inline: true },
+      { name: 'Start', value: `<t:${proposal.start}:R>`, inline: true },
+      { name: 'End', value: `<t:${proposal.end}:R>`, inline: true }
+    )
+    .setDescription(preview || ' ');
+
+  if (subs[proposal.space.id] || subs['*']) {
+    [...(subs['*'] || []), ...(subs[proposal.space.id] || [])].forEach(sub => {
+      sendMessage(sub.channel, {
+        content: `${sub.mention} `,
+        embeds: [embed],
+        components
+      });
+    });
+  }
+  return { success: true };
+};
+
+export default client;

--- a/src/helpers/proposal.ts
+++ b/src/helpers/proposal.ts
@@ -1,0 +1,47 @@
+import snapshot from '@snapshot-labs/snapshot.js';
+
+const hubURL = process.env.HUB_URL || 'https://hub.snapshot.org';
+
+export async function getProposal(id) {
+  let proposal: { [key: string]: any } | null = null;
+  const query = {
+    proposal: {
+      __args: {
+        id
+      },
+      space: {
+        id: true,
+        name: true,
+        avatar: true
+      },
+      id: true,
+      type: true,
+      author: true,
+      title: true,
+      body: true,
+      choices: true,
+      start: true,
+      end: true,
+      snapshot: true
+    }
+  };
+  const result = await snapshot.utils.subgraphRequest(`${hubURL}/graphql`, query);
+  if (result.errors) {
+    throw new Error(`[events] Errors in subgraph request for proposal id: ${id}`);
+  }
+  proposal = result.proposal || null;
+  return proposal;
+}
+
+export async function getProposalScores(proposalId) {
+  return snapshot.utils.getJSON(`${hubURL}/api/scores/${proposalId}`);
+}
+
+export async function checkSpace(space) {
+  try {
+    const spaceData = await snapshot.utils.getJSON(`${hubURL}/api/spaces/${space}`);
+    return spaceData?.name;
+  } catch (error) {
+    return false;
+  }
+}

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -1,0 +1,11 @@
+import { createHash } from 'crypto';
+
+export function shortenAddress(str: string = '') {
+  return `${str.slice(0, 6)}...${str.slice(str.length - 4)}`;
+}
+
+export function sha256(str: string) {
+  return createHash('sha256')
+    .update(str)
+    .digest('hex');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,17 @@
+import 'dotenv/config';
+import express from 'express';
+import bodyParser from 'body-parser';
+import cors from 'cors';
+import api from './api';
+import './client';
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(bodyParser.json({ limit: '8mb' }));
+app.use(bodyParser.urlencoded({ limit: '8mb', extended: false }));
+app.use(cors({ maxAge: 86400 }));
+
+app.use('/api', api);
+
+app.listen(PORT, () => console.log(`Listening at http://localhost:${PORT}`));

--- a/src/subscriptions.ts
+++ b/src/subscriptions.ts
@@ -1,0 +1,13 @@
+import db from './db/mysql';
+
+export let subs = {};
+
+export async function loadSubscriptions() {
+  const results = await db.queryAsync('SELECT * FROM subscriptions');
+  subs = {};
+  results.forEach(sub => {
+    if (!subs[sub.space]) subs[sub.space] = [];
+    subs[sub.space].push(sub);
+  });
+  console.log('Subscriptions', Object.keys(subs).length);
+}


### PR DESCRIPTION
Fixes partially [snapshot-webhook/40](https://github.com/snapshot-labs/snapshot-webhook/issues/40)

**Background**

This PR sets up the Discord Bot as a separate repo from [snapshot-webhook](https://github.com/snapshot-labs/snapshot-webhook)

**PR details**
The logic is moved from `snapshot-webhook` to this repo in the following way:
- sets up the Discord `client` and connects to the existing Snapshot bot
- exposes an API endpoint for notifying subscribers about the proposals which is to be called from `snapshot-webhook`
- uses the same DB as `snapshot-webhook`

Current implementation (there is an error with _Missing access_, haven't sorted it out yet but it must be my settings on Discord for the app):

![discordBot1](https://user-images.githubusercontent.com/39556343/198364147-df13d562-a1e7-4659-9d50-969c39bdc2fb.gif)

**Related PRs**
- will have to be merged before a change in snapshot-webhook, PR to come

**To Dos**
- [ ] would be great to refactor the client into separate files (easier to manage if there are new features in the future) -> might be done in separate PR
- [ ] set up ENV variables in prod required to initiate the `client` and `db`

@bonustrack @ChaituVR any comments welcome :pray: 